### PR TITLE
Add RadioCult.fm API integration

### DIFF
--- a/lib/config/radiocult_config.dart
+++ b/lib/config/radiocult_config.dart
@@ -1,0 +1,35 @@
+/// RadioCult API configuration
+///
+/// To use the RadioCult API, you need to:
+/// 1. Create an account at https://app.radiocult.fm
+/// 2. Go to Settings > API to get your station ID and API key
+/// 3. Update the values below with your credentials
+///
+/// API Key Types:
+/// - Publishable keys (pk_*): Read-only access, safe for frontend use
+/// - Secret keys (sk_*): Full access including write operations
+///
+/// For a Flutter app, use a publishable key (pk_*) for security.
+
+class RadioCultConfig {
+  /// Your RadioCult station ID
+  /// Found at: https://app.radiocult.fm/settings/cms/api
+  static const String stationId = 'YOUR_STATION_ID';
+
+  /// Your RadioCult API key
+  /// Use a publishable key (pk_*) for client-side applications
+  /// Found at: https://app.radiocult.fm/settings/cms/api
+  static const String apiKey = 'YOUR_API_KEY';
+
+  /// Whether RadioCult integration is enabled
+  /// Set to true once you have configured your credentials
+  static const bool isEnabled = false;
+
+  /// Validate that the configuration is properly set up
+  static bool get isConfigured {
+    return stationId != 'YOUR_STATION_ID' &&
+        apiKey != 'YOUR_API_KEY' &&
+        stationId.isNotEmpty &&
+        apiKey.isNotEmpty;
+  }
+}

--- a/lib/data/datasource/radiocult_remote_datasource.dart
+++ b/lib/data/datasource/radiocult_remote_datasource.dart
@@ -1,0 +1,33 @@
+import 'package:cuacfm/models/radiocult/radiocult.dart';
+
+/// Contract for RadioCult remote data source
+abstract class RadioCultRemoteDataSourceContract {
+  /// Get all artists for the station
+  Future<List<RadioCultArtist>> getArtists();
+
+  /// Get a specific artist by ID
+  Future<RadioCultArtist?> getArtistById(String artistId);
+
+  /// Get a specific artist by slug
+  Future<RadioCultArtist?> getArtistBySlug(String slug);
+
+  /// Get schedule for a specific artist
+  Future<List<RadioCultEvent>> getArtistSchedule(
+      String artistId, DateTime startDate, DateTime endDate);
+
+  /// Get current live status
+  Future<RadioCultLiveStatus?> getLiveStatus();
+
+  /// Get schedule events within a date range
+  Future<List<RadioCultEvent>> getSchedule(DateTime startDate, DateTime endDate,
+      {bool expandArtist = false});
+
+  /// Get last played tracks history
+  Future<List<RadioCultLastPlayed>> getHistory({int limit = 5});
+
+  /// Get all playlists
+  Future<List<RadioCultPlaylist>> getPlaylists();
+
+  /// Get all tags
+  Future<List<RadioCultTag>> getTags();
+}

--- a/lib/data/radiocult_repository.dart
+++ b/lib/data/radiocult_repository.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+
+import 'package:cuacfm/data/datasource/radiocult_remote_datasource.dart';
+import 'package:cuacfm/domain/repository/radiocult_repository_contract.dart';
+import 'package:cuacfm/domain/result/result.dart';
+import 'package:cuacfm/models/radiocult/radiocult.dart';
+
+/// Implementation of RadioCult repository
+class RadioCultRepository implements RadioCultRepositoryContract {
+  final RadioCultRemoteDataSourceContract remoteDataSource;
+
+  RadioCultRepository({required this.remoteDataSource});
+
+  @override
+  Future<Result<List<RadioCultArtist>>> getArtists() async {
+    List<RadioCultArtist> artists = await remoteDataSource.getArtists();
+    if (artists.isEmpty) {
+      return Error([], Status.fail, "Failed to fetch artists");
+    }
+    return Success(artists, Status.ok);
+  }
+
+  @override
+  Future<Result<RadioCultArtist>> getArtistById(String artistId) async {
+    RadioCultArtist? artist = await remoteDataSource.getArtistById(artistId);
+    if (artist == null) {
+      return Error(_emptyArtist(), Status.fail, "Artist not found");
+    }
+    return Success(artist, Status.ok);
+  }
+
+  @override
+  Future<Result<RadioCultArtist>> getArtistBySlug(String slug) async {
+    RadioCultArtist? artist = await remoteDataSource.getArtistBySlug(slug);
+    if (artist == null) {
+      return Error(_emptyArtist(), Status.fail, "Artist not found");
+    }
+    return Success(artist, Status.ok);
+  }
+
+  @override
+  Future<Result<List<RadioCultEvent>>> getArtistSchedule(
+      String artistId, DateTime startDate, DateTime endDate) async {
+    List<RadioCultEvent> events =
+        await remoteDataSource.getArtistSchedule(artistId, startDate, endDate);
+    if (events.isEmpty) {
+      return Error([], Status.fail, "No schedule found for artist");
+    }
+    return Success(events, Status.ok);
+  }
+
+  @override
+  Future<Result<RadioCultLiveStatus>> getLiveStatus() async {
+    RadioCultLiveStatus? status = await remoteDataSource.getLiveStatus();
+    if (status == null) {
+      return Error(_offAirStatus(), Status.fail, "Failed to fetch live status");
+    }
+    return Success(status, Status.ok);
+  }
+
+  @override
+  Future<Result<List<RadioCultEvent>>> getSchedule(
+      DateTime startDate, DateTime endDate,
+      {bool expandArtist = false}) async {
+    List<RadioCultEvent> events = await remoteDataSource.getSchedule(
+        startDate, endDate,
+        expandArtist: expandArtist);
+    if (events.isEmpty) {
+      return Error([], Status.fail, "No events found in schedule");
+    }
+    return Success(events, Status.ok);
+  }
+
+  @override
+  Future<Result<List<RadioCultLastPlayed>>> getHistory({int limit = 5}) async {
+    List<RadioCultLastPlayed> history =
+        await remoteDataSource.getHistory(limit: limit);
+    if (history.isEmpty) {
+      return Error([], Status.fail, "No history available");
+    }
+    return Success(history, Status.ok);
+  }
+
+  @override
+  Future<Result<List<RadioCultPlaylist>>> getPlaylists() async {
+    List<RadioCultPlaylist> playlists = await remoteDataSource.getPlaylists();
+    if (playlists.isEmpty) {
+      return Error([], Status.fail, "No playlists found");
+    }
+    return Success(playlists, Status.ok);
+  }
+
+  @override
+  Future<Result<List<RadioCultTag>>> getTags() async {
+    List<RadioCultTag> tags = await remoteDataSource.getTags();
+    if (tags.isEmpty) {
+      return Error([], Status.fail, "No tags found");
+    }
+    return Success(tags, Status.ok);
+  }
+
+  /// Create an empty artist for error cases
+  RadioCultArtist _emptyArtist() {
+    return RadioCultArtist(
+      id: '',
+      name: '',
+      stationId: '',
+      slug: '',
+    );
+  }
+
+  /// Create an off-air status for error cases
+  RadioCultLiveStatus _offAirStatus() {
+    return RadioCultLiveStatus(
+      status: RadioCultLiveStatusType.offAir,
+    );
+  }
+}

--- a/lib/domain/repository/radiocult_repository_contract.dart
+++ b/lib/domain/repository/radiocult_repository_contract.dart
@@ -1,0 +1,35 @@
+import 'package:cuacfm/domain/result/result.dart';
+import 'package:cuacfm/models/radiocult/radiocult.dart';
+
+/// Contract for RadioCult repository
+abstract class RadioCultRepositoryContract {
+  /// Get all artists for the station
+  Future<Result<List<RadioCultArtist>>> getArtists();
+
+  /// Get a specific artist by ID
+  Future<Result<RadioCultArtist>> getArtistById(String artistId);
+
+  /// Get a specific artist by slug
+  Future<Result<RadioCultArtist>> getArtistBySlug(String slug);
+
+  /// Get schedule for a specific artist
+  Future<Result<List<RadioCultEvent>>> getArtistSchedule(
+      String artistId, DateTime startDate, DateTime endDate);
+
+  /// Get current live status
+  Future<Result<RadioCultLiveStatus>> getLiveStatus();
+
+  /// Get schedule events within a date range
+  Future<Result<List<RadioCultEvent>>> getSchedule(
+      DateTime startDate, DateTime endDate,
+      {bool expandArtist = false});
+
+  /// Get last played tracks history
+  Future<Result<List<RadioCultLastPlayed>>> getHistory({int limit = 5});
+
+  /// Get all playlists
+  Future<Result<List<RadioCultPlaylist>>> getPlaylists();
+
+  /// Get all tags
+  Future<Result<List<RadioCultTag>>> getTags();
+}

--- a/lib/domain/usecase/radiocult/get_radiocult_artist_schedule_use_case.dart
+++ b/lib/domain/usecase/radiocult/get_radiocult_artist_schedule_use_case.dart
@@ -1,0 +1,35 @@
+import 'package:cuacfm/domain/invoker/base_use_case.dart';
+import 'package:cuacfm/domain/repository/radiocult_repository_contract.dart';
+import 'package:cuacfm/domain/result/result.dart';
+import 'package:cuacfm/models/radiocult/radiocult.dart';
+
+/// Parameters for getting artist schedule
+class GetArtistScheduleParams {
+  final String artistId;
+  final DateTime startDate;
+  final DateTime endDate;
+
+  GetArtistScheduleParams({
+    required this.artistId,
+    required this.startDate,
+    required this.endDate,
+  });
+}
+
+class GetRadioCultArtistScheduleUseCase
+    extends BaseUseCase<GetArtistScheduleParams, List<RadioCultEvent>> {
+  RadioCultRepositoryContract repository;
+
+  GetRadioCultArtistScheduleUseCase({required this.repository});
+
+  @override
+  void invoke() {
+    if (params != null) {
+      notifyListeners(repository.getArtistSchedule(
+        params!.artistId,
+        params!.startDate,
+        params!.endDate,
+      ));
+    }
+  }
+}

--- a/lib/domain/usecase/radiocult/get_radiocult_artist_use_case.dart
+++ b/lib/domain/usecase/radiocult/get_radiocult_artist_use_case.dart
@@ -1,0 +1,28 @@
+import 'package:cuacfm/domain/invoker/base_use_case.dart';
+import 'package:cuacfm/domain/repository/radiocult_repository_contract.dart';
+import 'package:cuacfm/domain/result/result.dart';
+import 'package:cuacfm/models/radiocult/radiocult.dart';
+
+/// Parameters for getting a single artist
+class GetArtistParams {
+  final String? artistId;
+  final String? slug;
+
+  GetArtistParams({this.artistId, this.slug});
+}
+
+class GetRadioCultArtistUseCase
+    extends BaseUseCase<GetArtistParams, RadioCultArtist> {
+  RadioCultRepositoryContract repository;
+
+  GetRadioCultArtistUseCase({required this.repository});
+
+  @override
+  void invoke() {
+    if (params?.artistId != null) {
+      notifyListeners(repository.getArtistById(params!.artistId!));
+    } else if (params?.slug != null) {
+      notifyListeners(repository.getArtistBySlug(params!.slug!));
+    }
+  }
+}

--- a/lib/domain/usecase/radiocult/get_radiocult_artists_use_case.dart
+++ b/lib/domain/usecase/radiocult/get_radiocult_artists_use_case.dart
@@ -1,0 +1,16 @@
+import 'package:cuacfm/domain/invoker/base_use_case.dart';
+import 'package:cuacfm/domain/repository/radiocult_repository_contract.dart';
+import 'package:cuacfm/domain/result/result.dart';
+import 'package:cuacfm/models/radiocult/radiocult.dart';
+
+class GetRadioCultArtistsUseCase
+    extends BaseUseCase<DataPolicy, List<RadioCultArtist>> {
+  RadioCultRepositoryContract repository;
+
+  GetRadioCultArtistsUseCase({required this.repository});
+
+  @override
+  void invoke() {
+    notifyListeners(repository.getArtists());
+  }
+}

--- a/lib/domain/usecase/radiocult/get_radiocult_history_use_case.dart
+++ b/lib/domain/usecase/radiocult/get_radiocult_history_use_case.dart
@@ -1,0 +1,24 @@
+import 'package:cuacfm/domain/invoker/base_use_case.dart';
+import 'package:cuacfm/domain/repository/radiocult_repository_contract.dart';
+import 'package:cuacfm/domain/result/result.dart';
+import 'package:cuacfm/models/radiocult/radiocult.dart';
+
+/// Parameters for getting history
+class GetHistoryParams {
+  final int limit;
+
+  GetHistoryParams({this.limit = 5});
+}
+
+class GetRadioCultHistoryUseCase
+    extends BaseUseCase<GetHistoryParams, List<RadioCultLastPlayed>> {
+  RadioCultRepositoryContract repository;
+
+  GetRadioCultHistoryUseCase({required this.repository});
+
+  @override
+  void invoke() {
+    final limit = params?.limit ?? 5;
+    notifyListeners(repository.getHistory(limit: limit));
+  }
+}

--- a/lib/domain/usecase/radiocult/get_radiocult_live_status_use_case.dart
+++ b/lib/domain/usecase/radiocult/get_radiocult_live_status_use_case.dart
@@ -1,0 +1,16 @@
+import 'package:cuacfm/domain/invoker/base_use_case.dart';
+import 'package:cuacfm/domain/repository/radiocult_repository_contract.dart';
+import 'package:cuacfm/domain/result/result.dart';
+import 'package:cuacfm/models/radiocult/radiocult.dart';
+
+class GetRadioCultLiveStatusUseCase
+    extends BaseUseCase<DataPolicy, RadioCultLiveStatus> {
+  RadioCultRepositoryContract repository;
+
+  GetRadioCultLiveStatusUseCase({required this.repository});
+
+  @override
+  void invoke() {
+    notifyListeners(repository.getLiveStatus());
+  }
+}

--- a/lib/domain/usecase/radiocult/get_radiocult_playlists_use_case.dart
+++ b/lib/domain/usecase/radiocult/get_radiocult_playlists_use_case.dart
@@ -1,0 +1,16 @@
+import 'package:cuacfm/domain/invoker/base_use_case.dart';
+import 'package:cuacfm/domain/repository/radiocult_repository_contract.dart';
+import 'package:cuacfm/domain/result/result.dart';
+import 'package:cuacfm/models/radiocult/radiocult.dart';
+
+class GetRadioCultPlaylistsUseCase
+    extends BaseUseCase<DataPolicy, List<RadioCultPlaylist>> {
+  RadioCultRepositoryContract repository;
+
+  GetRadioCultPlaylistsUseCase({required this.repository});
+
+  @override
+  void invoke() {
+    notifyListeners(repository.getPlaylists());
+  }
+}

--- a/lib/domain/usecase/radiocult/get_radiocult_schedule_use_case.dart
+++ b/lib/domain/usecase/radiocult/get_radiocult_schedule_use_case.dart
@@ -1,0 +1,35 @@
+import 'package:cuacfm/domain/invoker/base_use_case.dart';
+import 'package:cuacfm/domain/repository/radiocult_repository_contract.dart';
+import 'package:cuacfm/domain/result/result.dart';
+import 'package:cuacfm/models/radiocult/radiocult.dart';
+
+/// Parameters for getting schedule
+class GetScheduleParams {
+  final DateTime startDate;
+  final DateTime endDate;
+  final bool expandArtist;
+
+  GetScheduleParams({
+    required this.startDate,
+    required this.endDate,
+    this.expandArtist = false,
+  });
+}
+
+class GetRadioCultScheduleUseCase
+    extends BaseUseCase<GetScheduleParams, List<RadioCultEvent>> {
+  RadioCultRepositoryContract repository;
+
+  GetRadioCultScheduleUseCase({required this.repository});
+
+  @override
+  void invoke() {
+    if (params != null) {
+      notifyListeners(repository.getSchedule(
+        params!.startDate,
+        params!.endDate,
+        expandArtist: params!.expandArtist,
+      ));
+    }
+  }
+}

--- a/lib/domain/usecase/radiocult/get_radiocult_tags_use_case.dart
+++ b/lib/domain/usecase/radiocult/get_radiocult_tags_use_case.dart
@@ -1,0 +1,16 @@
+import 'package:cuacfm/domain/invoker/base_use_case.dart';
+import 'package:cuacfm/domain/repository/radiocult_repository_contract.dart';
+import 'package:cuacfm/domain/result/result.dart';
+import 'package:cuacfm/models/radiocult/radiocult.dart';
+
+class GetRadioCultTagsUseCase
+    extends BaseUseCase<DataPolicy, List<RadioCultTag>> {
+  RadioCultRepositoryContract repository;
+
+  GetRadioCultTagsUseCase({required this.repository});
+
+  @override
+  void invoke() {
+    notifyListeners(repository.getTags());
+  }
+}

--- a/lib/domain/usecase/radiocult/radiocult_use_cases.dart
+++ b/lib/domain/usecase/radiocult/radiocult_use_cases.dart
@@ -1,0 +1,11 @@
+/// RadioCult use cases barrel file
+/// Export all RadioCult use cases from a single import
+
+export 'get_radiocult_artist_schedule_use_case.dart';
+export 'get_radiocult_artist_use_case.dart';
+export 'get_radiocult_artists_use_case.dart';
+export 'get_radiocult_history_use_case.dart';
+export 'get_radiocult_live_status_use_case.dart';
+export 'get_radiocult_playlists_use_case.dart';
+export 'get_radiocult_schedule_use_case.dart';
+export 'get_radiocult_tags_use_case.dart';

--- a/lib/injector/dependency_injector.dart
+++ b/lib/injector/dependency_injector.dart
@@ -1,5 +1,6 @@
 import 'package:just_audio/just_audio.dart';
 import 'package:cuacfm/data/datasource/radioco_remote_datasource.dart';
+import 'package:cuacfm/data/datasource/radiocult_remote_datasource.dart';
 import 'package:cuacfm/domain/usecase/get_all_podcast_use_case.dart';
 import 'package:cuacfm/domain/usecase/get_episodes_use_case.dart';
 import 'package:cuacfm/domain/usecase/get_live_program_use_case.dart';
@@ -7,12 +8,19 @@ import 'package:cuacfm/domain/usecase/get_news_use_case.dart';
 import 'package:cuacfm/domain/usecase/get_outstanding_use_case.dart';
 import 'package:cuacfm/domain/usecase/get_station_use_case.dart';
 import 'package:cuacfm/domain/usecase/get_timetable_use_case.dart';
+import 'package:cuacfm/domain/usecase/radiocult/radiocult_use_cases.dart';
 import 'package:cuacfm/models/radiostation.dart';
 import 'package:cuacfm/remote-data-source/network/radioco_api.dart';
+import 'package:cuacfm/remote-data-source/network/radiocult_api.dart';
 import 'package:cuacfm/data/radiocom-repository.dart';
+import 'package:cuacfm/data/radiocult_repository.dart';
 import 'package:cuacfm/domain/invoker/invoker.dart';
 import 'package:cuacfm/domain/repository/radiocom_repository_contract.dart';
+import 'package:cuacfm/domain/repository/radiocult_repository_contract.dart';
 import 'package:cuacfm/remote-data-source/radioco/radiocom_remote_datasource.dart';
+import 'package:cuacfm/remote-data-source/radiocult/radiocult_remote_datasource.dart';
+import 'package:cuacfm/utils/simple_client.dart';
+import 'package:cuacfm/config/radiocult_config.dart';
 import 'package:cuacfm/ui/home/home_presenter.dart';
 import 'package:cuacfm/ui/home/home_router.dart';
 import 'package:cuacfm/ui/home/home_view.dart';
@@ -54,10 +62,14 @@ class DependencyInjector {
 
   loadModules() {
     loadPlayerModules();
-    loadPresentationModules();
-    loadDomainModules();
-    loadDataModules();
+    // Load in dependency order: remote -> data -> domain -> presentation
     loadRemoteDatasourceModules();
+    loadRadioCultRemoteDatasourceModules();
+    loadDataModules();
+    loadRadioCultDataModules();
+    loadDomainModules();
+    loadRadioCultDomainModules();
+    loadPresentationModules();
   }
 
   injectByView(dynamic view) {
@@ -248,9 +260,80 @@ class DependencyInjector {
 
   loadRemoteDatasourceModules() {
     injector.registerDependency<CUACClient>(() => CUACClient(), override: true);
+    injector.registerDependency<SimpleClient>(() => SimpleClient(), override: true);
     injector.registerDependency<RadiocoAPIContract>(() => RadiocoAPI());
     injector.registerDependency<RadiocoRemoteDataSourceContract>(() {
       return new RadiocoRemoteDataSource();
+    });
+  }
+
+  /// Load RadioCult remote data source modules
+  /// Uses credentials from RadioCultConfig by default
+  /// You can also pass custom credentials as parameters
+  loadRadioCultRemoteDatasourceModules({
+    String? stationId,
+    String? apiKey,
+  }) {
+    final effectiveStationId = stationId ?? RadioCultConfig.stationId;
+    final effectiveApiKey = apiKey ?? RadioCultConfig.apiKey;
+
+    injector.registerDependency<RadioCultAPIContract>(
+      () => RadioCultAPI(stationId: effectiveStationId, apiKey: effectiveApiKey),
+      override: true,
+    );
+    injector.registerDependency<RadioCultRemoteDataSourceContract>(() {
+      return RadioCultRemoteDataSource();
+    });
+  }
+
+  /// Load RadioCult data modules (repository)
+  loadRadioCultDataModules() {
+    injector.registerDependency<RadioCultRepositoryContract>(() {
+      var remoteDataSource = injector.get<RadioCultRemoteDataSourceContract>();
+      return RadioCultRepository(remoteDataSource: remoteDataSource);
+    });
+  }
+
+  /// Load RadioCult domain modules (use cases)
+  loadRadioCultDomainModules() {
+    injector.registerDependency<GetRadioCultArtistsUseCase>(() {
+      var repository = injector.get<RadioCultRepositoryContract>();
+      return GetRadioCultArtistsUseCase(repository: repository);
+    });
+
+    injector.registerDependency<GetRadioCultArtistUseCase>(() {
+      var repository = injector.get<RadioCultRepositoryContract>();
+      return GetRadioCultArtistUseCase(repository: repository);
+    });
+
+    injector.registerDependency<GetRadioCultLiveStatusUseCase>(() {
+      var repository = injector.get<RadioCultRepositoryContract>();
+      return GetRadioCultLiveStatusUseCase(repository: repository);
+    });
+
+    injector.registerDependency<GetRadioCultScheduleUseCase>(() {
+      var repository = injector.get<RadioCultRepositoryContract>();
+      return GetRadioCultScheduleUseCase(repository: repository);
+    });
+
+    injector.registerDependency<GetRadioCultHistoryUseCase>(() {
+      var repository = injector.get<RadioCultRepositoryContract>();
+      return GetRadioCultHistoryUseCase(repository: repository);
+    });
+
+    injector.registerDependency<GetRadioCultPlaylistsUseCase>(() {
+      var repository = injector.get<RadioCultRepositoryContract>();
+      return GetRadioCultPlaylistsUseCase(repository: repository);
+    });
+
+    injector.registerDependency<GetRadioCultTagsUseCase>(() {
+      var repository = injector.get<RadioCultRepositoryContract>();
+      return GetRadioCultTagsUseCase(repository: repository);
+    });
+
+    injector.registerDependency<GetRadioCultArtistScheduleUseCase>(() {
+      var repository = injector.get<RadioCultRepositoryContract>();
+      return GetRadioCultArtistScheduleUseCase(repository: repository);
     });
   }
 }

--- a/lib/models/radiocult/radiocult.dart
+++ b/lib/models/radiocult/radiocult.dart
@@ -1,0 +1,10 @@
+/// RadioCult models barrel file
+/// Export all RadioCult models from a single import
+
+export 'radiocult_artist.dart';
+export 'radiocult_event.dart';
+export 'radiocult_history.dart';
+export 'radiocult_live_status.dart';
+export 'radiocult_metadata.dart';
+export 'radiocult_playlist.dart';
+export 'radiocult_tag.dart';

--- a/lib/models/radiocult/radiocult_artist.dart
+++ b/lib/models/radiocult/radiocult_artist.dart
@@ -1,0 +1,114 @@
+/// RadioCult Artist model
+/// Represents an artist/show host in the RadioCult system
+class RadioCultArtist {
+  final String id;
+  final String name;
+  final String stationId;
+  final String slug;
+  final Map<String, String> socials;
+  final String? shareableLinkId;
+  final String? description;
+  final RadioCultArtwork? logo;
+  final List<String> tags;
+  final List<String> genres;
+  final String? country;
+  final DateTime? modified;
+  final DateTime? created;
+
+  RadioCultArtist({
+    required this.id,
+    required this.name,
+    required this.stationId,
+    required this.slug,
+    this.socials = const {},
+    this.shareableLinkId,
+    this.description,
+    this.logo,
+    this.tags = const [],
+    this.genres = const [],
+    this.country,
+    this.modified,
+    this.created,
+  });
+
+  factory RadioCultArtist.fromJson(Map<String, dynamic> json) {
+    return RadioCultArtist(
+      id: json['id'] ?? '',
+      name: json['name'] ?? '',
+      stationId: json['stationId'] ?? '',
+      slug: json['slug'] ?? '',
+      socials: json['socials'] != null
+          ? Map<String, String>.from(json['socials'])
+          : {},
+      shareableLinkId: json['shareableLinkId'],
+      description: json['description'],
+      logo: json['logo'] != null
+          ? RadioCultArtwork.fromJson(json['logo'])
+          : null,
+      tags: json['tags'] != null ? List<String>.from(json['tags']) : [],
+      genres: json['genres'] != null ? List<String>.from(json['genres']) : [],
+      country: json['country'],
+      modified:
+          json['modified'] != null ? DateTime.tryParse(json['modified']) : null,
+      created:
+          json['created'] != null ? DateTime.tryParse(json['created']) : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'stationId': stationId,
+      'slug': slug,
+      'socials': socials,
+      'shareableLinkId': shareableLinkId,
+      'description': description,
+      'logo': logo?.toJson(),
+      'tags': tags,
+      'genres': genres,
+      'country': country,
+      'modified': modified?.toIso8601String(),
+      'created': created?.toIso8601String(),
+    };
+  }
+
+  /// Get the best available logo URL
+  String? get logoUrl {
+    if (logo == null) return null;
+    return logo!.large ?? logo!.medium ?? logo!.small ?? logo!.thumbnail;
+  }
+}
+
+/// Artwork with multiple resolutions
+class RadioCultArtwork {
+  final String? thumbnail;
+  final String? small;
+  final String? medium;
+  final String? large;
+
+  RadioCultArtwork({
+    this.thumbnail,
+    this.small,
+    this.medium,
+    this.large,
+  });
+
+  factory RadioCultArtwork.fromJson(Map<String, dynamic> json) {
+    return RadioCultArtwork(
+      thumbnail: json['thumbnail'],
+      small: json['small'],
+      medium: json['medium'],
+      large: json['large'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'thumbnail': thumbnail,
+      'small': small,
+      'medium': medium,
+      'large': large,
+    };
+  }
+}

--- a/lib/models/radiocult/radiocult_event.dart
+++ b/lib/models/radiocult/radiocult_event.dart
@@ -1,0 +1,126 @@
+import 'radiocult_artist.dart';
+
+/// RadioCult Event model
+/// Represents a scheduled event/show in the RadioCult system
+class RadioCultEvent {
+  final String id;
+  final String stationId;
+  final String title;
+  final DateTime startDateUtc;
+  final DateTime endDateUtc;
+  final String? description;
+  final int duration; // in minutes
+  final String? timezone;
+  final String? color;
+  final RadioCultEventMedia? media;
+  final List<String> artistIds;
+  final bool isRecurring;
+  final DateTime? modified;
+  final DateTime? created;
+
+  // Expanded artist data (when expand=artist is used)
+  final List<RadioCultArtist>? artists;
+
+  RadioCultEvent({
+    required this.id,
+    required this.stationId,
+    required this.title,
+    required this.startDateUtc,
+    required this.endDateUtc,
+    this.description,
+    this.duration = 0,
+    this.timezone,
+    this.color,
+    this.media,
+    this.artistIds = const [],
+    this.isRecurring = false,
+    this.modified,
+    this.created,
+    this.artists,
+  });
+
+  factory RadioCultEvent.fromJson(Map<String, dynamic> json) {
+    return RadioCultEvent(
+      id: json['id'] ?? '',
+      stationId: json['stationId'] ?? '',
+      title: json['title'] ?? '',
+      startDateUtc: DateTime.parse(
+          json['startDateUtc'] ?? DateTime.now().toIso8601String()),
+      endDateUtc: DateTime.parse(
+          json['endDateUtc'] ?? DateTime.now().toIso8601String()),
+      description: json['description'],
+      duration: json['duration'] ?? 0,
+      timezone: json['timezone'],
+      color: json['color'],
+      media: json['media'] != null
+          ? RadioCultEventMedia.fromJson(json['media'])
+          : null,
+      artistIds: json['artistIds'] != null
+          ? List<String>.from(json['artistIds'])
+          : [],
+      isRecurring: json['isRecurring'] ?? false,
+      modified:
+          json['modified'] != null ? DateTime.tryParse(json['modified']) : null,
+      created:
+          json['created'] != null ? DateTime.tryParse(json['created']) : null,
+      artists: json['artists'] != null
+          ? (json['artists'] as List)
+              .map((a) => RadioCultArtist.fromJson(a))
+              .toList()
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'stationId': stationId,
+      'title': title,
+      'startDateUtc': startDateUtc.toIso8601String(),
+      'endDateUtc': endDateUtc.toIso8601String(),
+      'description': description,
+      'duration': duration,
+      'timezone': timezone,
+      'color': color,
+      'media': media?.toJson(),
+      'artistIds': artistIds,
+      'isRecurring': isRecurring,
+      'modified': modified?.toIso8601String(),
+      'created': created?.toIso8601String(),
+      'artists': artists?.map((a) => a.toJson()).toList(),
+    };
+  }
+}
+
+/// Event media type (live, mix, or playlist)
+class RadioCultEventMedia {
+  final String type; // 'live', 'mix', or 'playlist'
+  final String? playlistId;
+  final String? mixId;
+
+  RadioCultEventMedia({
+    required this.type,
+    this.playlistId,
+    this.mixId,
+  });
+
+  factory RadioCultEventMedia.fromJson(Map<String, dynamic> json) {
+    return RadioCultEventMedia(
+      type: json['type'] ?? 'live',
+      playlistId: json['playlistId'],
+      mixId: json['mixId'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'type': type,
+      'playlistId': playlistId,
+      'mixId': mixId,
+    };
+  }
+
+  bool get isLive => type == 'live';
+  bool get isMix => type == 'mix';
+  bool get isPlaylist => type == 'playlist';
+}

--- a/lib/models/radiocult/radiocult_history.dart
+++ b/lib/models/radiocult/radiocult_history.dart
@@ -1,0 +1,56 @@
+import 'radiocult_artist.dart';
+
+/// RadioCult Last Played / History model
+/// Represents a track that was recently played
+class RadioCultLastPlayed {
+  final DateTime playoutStart;
+  final String? title;
+  final String? artist;
+  final String? album;
+  final RadioCultArtwork? artwork;
+
+  RadioCultLastPlayed({
+    required this.playoutStart,
+    this.title,
+    this.artist,
+    this.album,
+    this.artwork,
+  });
+
+  factory RadioCultLastPlayed.fromJson(Map<String, dynamic> json) {
+    return RadioCultLastPlayed(
+      playoutStart: DateTime.parse(
+          json['playoutStart'] ?? DateTime.now().toIso8601String()),
+      title: json['title'],
+      artist: json['artist'],
+      album: json['album'],
+      artwork: json['artwork'] != null
+          ? RadioCultArtwork.fromJson(json['artwork'])
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'playoutStart': playoutStart.toIso8601String(),
+      'title': title,
+      'artist': artist,
+      'album': album,
+      'artwork': artwork?.toJson(),
+    };
+  }
+
+  /// Get the best available artwork URL
+  String? get artworkUrl {
+    if (artwork == null) return null;
+    return artwork!.large ?? artwork!.medium ?? artwork!.small ?? artwork!.thumbnail;
+  }
+
+  /// Get display text (title - artist)
+  String get displayText {
+    final parts = <String>[];
+    if (title != null && title!.isNotEmpty) parts.add(title!);
+    if (artist != null && artist!.isNotEmpty) parts.add(artist!);
+    return parts.join(' - ');
+  }
+}

--- a/lib/models/radiocult/radiocult_live_status.dart
+++ b/lib/models/radiocult/radiocult_live_status.dart
@@ -1,0 +1,152 @@
+import 'radiocult_artist.dart';
+import 'radiocult_event.dart';
+import 'radiocult_metadata.dart';
+
+/// Live status types returned by the RadioCult API
+enum RadioCultLiveStatusType {
+  schedule, // A scheduled event is currently playing
+  offAir, // Station is off air
+  defaultPlaylist, // Default playlist is playing (no scheduled event)
+}
+
+/// RadioCult Live Status model
+/// Represents the current streaming status of a station
+class RadioCultLiveStatus {
+  final RadioCultLiveStatusType status;
+  final RadioCultEvent? event;
+  final RadioCultMetadata? metadata;
+  final RadioCultMusicRecognition? musicRecognition;
+
+  RadioCultLiveStatus({
+    required this.status,
+    this.event,
+    this.metadata,
+    this.musicRecognition,
+  });
+
+  factory RadioCultLiveStatus.fromJson(Map<String, dynamic> json) {
+    RadioCultLiveStatusType statusType;
+    switch (json['status']) {
+      case 'schedule':
+        statusType = RadioCultLiveStatusType.schedule;
+        break;
+      case 'offAir':
+        statusType = RadioCultLiveStatusType.offAir;
+        break;
+      case 'defaultPlaylist':
+        statusType = RadioCultLiveStatusType.defaultPlaylist;
+        break;
+      default:
+        statusType = RadioCultLiveStatusType.offAir;
+    }
+
+    return RadioCultLiveStatus(
+      status: statusType,
+      event: json['event'] != null
+          ? RadioCultEvent.fromJson(json['event'])
+          : null,
+      metadata: json['metadata'] != null
+          ? RadioCultMetadata.fromJson(json['metadata'])
+          : null,
+      musicRecognition: json['musicRecognition'] != null
+          ? RadioCultMusicRecognition.fromJson(json['musicRecognition'])
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    String statusString;
+    switch (status) {
+      case RadioCultLiveStatusType.schedule:
+        statusString = 'schedule';
+        break;
+      case RadioCultLiveStatusType.offAir:
+        statusString = 'offAir';
+        break;
+      case RadioCultLiveStatusType.defaultPlaylist:
+        statusString = 'defaultPlaylist';
+        break;
+    }
+
+    return {
+      'status': statusString,
+      'event': event?.toJson(),
+      'metadata': metadata?.toJson(),
+      'musicRecognition': musicRecognition?.toJson(),
+    };
+  }
+
+  bool get isLive => status == RadioCultLiveStatusType.schedule;
+  bool get isOffAir => status == RadioCultLiveStatusType.offAir;
+  bool get isDefaultPlaylist =>
+      status == RadioCultLiveStatusType.defaultPlaylist;
+
+  /// Get the current show/event title
+  String get currentTitle {
+    if (event != null) return event!.title;
+    if (metadata != null) return metadata!.title ?? 'Unknown';
+    return 'Off Air';
+  }
+
+  /// Get the current artist name
+  String? get currentArtist {
+    if (metadata != null) return metadata!.artist;
+    if (event != null && event!.artists != null && event!.artists!.isNotEmpty) {
+      return event!.artists!.first.name;
+    }
+    return null;
+  }
+}
+
+/// Music recognition data (when 24/7 Music Recognition is enabled)
+class RadioCultMusicRecognition {
+  final String status; // 'match' or 'noMatch'
+  final String? title;
+  final String? artist;
+  final String? album;
+  final String? spotifyId;
+  final String? youtubeId;
+  final double? confidence;
+  final RadioCultArtwork? artwork;
+
+  RadioCultMusicRecognition({
+    required this.status,
+    this.title,
+    this.artist,
+    this.album,
+    this.spotifyId,
+    this.youtubeId,
+    this.confidence,
+    this.artwork,
+  });
+
+  factory RadioCultMusicRecognition.fromJson(Map<String, dynamic> json) {
+    return RadioCultMusicRecognition(
+      status: json['status'] ?? 'noMatch',
+      title: json['title'],
+      artist: json['artist'],
+      album: json['album'],
+      spotifyId: json['spotifyId'],
+      youtubeId: json['youtubeId'],
+      confidence: json['confidence']?.toDouble(),
+      artwork: json['artwork'] != null
+          ? RadioCultArtwork.fromJson(json['artwork'])
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'status': status,
+      'title': title,
+      'artist': artist,
+      'album': album,
+      'spotifyId': spotifyId,
+      'youtubeId': youtubeId,
+      'confidence': confidence,
+      'artwork': artwork?.toJson(),
+    };
+  }
+
+  bool get hasMatch => status == 'match';
+}

--- a/lib/models/radiocult/radiocult_metadata.dart
+++ b/lib/models/radiocult/radiocult_metadata.dart
@@ -1,0 +1,83 @@
+import 'radiocult_artist.dart';
+
+/// RadioCult Metadata model
+/// Represents track/song metadata in the RadioCult system
+class RadioCultMetadata {
+  final String? title;
+  final String? filename;
+  final int? duration; // in seconds
+  final String? album;
+  final String? artist;
+  final int? playoutStartUnixTimestamp;
+  final String? playoutStartIsoTimestamp;
+  final RadioCultArtwork? artwork;
+  final String? notes;
+
+  RadioCultMetadata({
+    this.title,
+    this.filename,
+    this.duration,
+    this.album,
+    this.artist,
+    this.playoutStartUnixTimestamp,
+    this.playoutStartIsoTimestamp,
+    this.artwork,
+    this.notes,
+  });
+
+  factory RadioCultMetadata.fromJson(Map<String, dynamic> json) {
+    return RadioCultMetadata(
+      title: json['title'],
+      filename: json['filename'],
+      duration: json['duration'],
+      album: json['album'],
+      artist: json['artist'],
+      playoutStartUnixTimestamp: json['playoutStartUnixTimestamp'],
+      playoutStartIsoTimestamp: json['playoutStartIsoTimestamp'],
+      artwork: json['artwork'] != null
+          ? RadioCultArtwork.fromJson(json['artwork'])
+          : null,
+      notes: json['notes'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'title': title,
+      'filename': filename,
+      'duration': duration,
+      'album': album,
+      'artist': artist,
+      'playoutStartUnixTimestamp': playoutStartUnixTimestamp,
+      'playoutStartIsoTimestamp': playoutStartIsoTimestamp,
+      'artwork': artwork?.toJson(),
+      'notes': notes,
+    };
+  }
+
+  /// Get the best available artwork URL
+  String? get artworkUrl {
+    if (artwork == null) return null;
+    return artwork!.large ?? artwork!.medium ?? artwork!.small ?? artwork!.thumbnail;
+  }
+
+  /// Get formatted duration string
+  String get formattedDuration {
+    if (duration == null) return '--:--';
+    final minutes = duration! ~/ 60;
+    final seconds = duration! % 60;
+    return '${minutes.toString().padLeft(2, '0')}:${seconds.toString().padLeft(2, '0')}';
+  }
+
+  /// Get playout start time as DateTime
+  DateTime? get playoutStartTime {
+    if (playoutStartIsoTimestamp != null) {
+      return DateTime.tryParse(playoutStartIsoTimestamp!);
+    }
+    if (playoutStartUnixTimestamp != null) {
+      return DateTime.fromMillisecondsSinceEpoch(
+          playoutStartUnixTimestamp! * 1000);
+    }
+    return null;
+  }
+}

--- a/lib/models/radiocult/radiocult_playlist.dart
+++ b/lib/models/radiocult/radiocult_playlist.dart
@@ -1,0 +1,61 @@
+/// RadioCult Playlist model
+/// Represents a playlist in the RadioCult system
+class RadioCultPlaylist {
+  final String id;
+  final String stationId;
+  final String name;
+  final String? description;
+  final int trackCount;
+  final int totalDuration; // in seconds
+  final DateTime? modified;
+  final DateTime? created;
+
+  RadioCultPlaylist({
+    required this.id,
+    required this.stationId,
+    required this.name,
+    this.description,
+    this.trackCount = 0,
+    this.totalDuration = 0,
+    this.modified,
+    this.created,
+  });
+
+  factory RadioCultPlaylist.fromJson(Map<String, dynamic> json) {
+    return RadioCultPlaylist(
+      id: json['id'] ?? '',
+      stationId: json['stationId'] ?? '',
+      name: json['name'] ?? '',
+      description: json['description'],
+      trackCount: json['trackCount'] ?? 0,
+      totalDuration: json['totalDuration'] ?? 0,
+      modified:
+          json['modified'] != null ? DateTime.tryParse(json['modified']) : null,
+      created:
+          json['created'] != null ? DateTime.tryParse(json['created']) : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'stationId': stationId,
+      'name': name,
+      'description': description,
+      'trackCount': trackCount,
+      'totalDuration': totalDuration,
+      'modified': modified?.toIso8601String(),
+      'created': created?.toIso8601String(),
+    };
+  }
+
+  /// Get formatted total duration string
+  String get formattedDuration {
+    final hours = totalDuration ~/ 3600;
+    final minutes = (totalDuration % 3600) ~/ 60;
+    if (hours > 0) {
+      return '${hours}h ${minutes}m';
+    }
+    return '${minutes}m';
+  }
+}

--- a/lib/models/radiocult/radiocult_tag.dart
+++ b/lib/models/radiocult/radiocult_tag.dart
@@ -1,0 +1,43 @@
+/// RadioCult Tag model
+/// Represents a tag for categorizing media in the RadioCult system
+class RadioCultTag {
+  final String id;
+  final String stationId;
+  final String name;
+  final String? color;
+  final DateTime? modified;
+  final DateTime? created;
+
+  RadioCultTag({
+    required this.id,
+    required this.stationId,
+    required this.name,
+    this.color,
+    this.modified,
+    this.created,
+  });
+
+  factory RadioCultTag.fromJson(Map<String, dynamic> json) {
+    return RadioCultTag(
+      id: json['id'] ?? '',
+      stationId: json['stationId'] ?? '',
+      name: json['name'] ?? '',
+      color: json['color'],
+      modified:
+          json['modified'] != null ? DateTime.tryParse(json['modified']) : null,
+      created:
+          json['created'] != null ? DateTime.tryParse(json['created']) : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'stationId': stationId,
+      'name': name,
+      'color': color,
+      'modified': modified?.toIso8601String(),
+      'created': created?.toIso8601String(),
+    };
+  }
+}

--- a/lib/remote-data-source/network/radiocult_api.dart
+++ b/lib/remote-data-source/network/radiocult_api.dart
@@ -1,0 +1,89 @@
+/// RadioCult API configuration
+/// Documentation: https://www.radiocult.fm/docs/api
+///
+/// Authentication: API key passed via 'x-api-key' header
+/// - Publishable keys (pk_*): Read-only access, safe for frontend use
+/// - Secret keys (sk_*): Full access including write operations
+
+abstract class RadioCultAPIContract {
+  String get baseUrl;
+  String get stationId;
+  String get apiKey;
+
+  // Artists endpoints
+  String get artists;
+  String artistById(String artistId);
+  String artistBySlug(String slug);
+  String artistSchedule(String artistId);
+
+  // Schedule endpoints
+  String get scheduleLive;
+  String get schedule;
+
+  // History endpoints
+  String get historyLatest;
+
+  // Media endpoints (may be disabled by default)
+  String get playlists;
+  String get tags;
+}
+
+class RadioCultAPI implements RadioCultAPIContract {
+  final String _stationId;
+  final String _apiKey;
+
+  RadioCultAPI({required String stationId, required String apiKey})
+      : _stationId = stationId,
+        _apiKey = apiKey;
+
+  @override
+  String get baseUrl => "https://api.radiocult.fm";
+
+  @override
+  String get stationId => _stationId;
+
+  @override
+  String get apiKey => _apiKey;
+
+  // Artists endpoints
+  @override
+  String get artists => "/api/station/$_stationId/artists";
+
+  @override
+  String artistById(String artistId) =>
+      "/api/station/$_stationId/artists/$artistId";
+
+  @override
+  String artistBySlug(String slug) => "/api/station/$_stationId/artists/$slug";
+
+  @override
+  String artistSchedule(String artistId) =>
+      "/api/station/$_stationId/artists/$artistId/schedule";
+
+  // Schedule endpoints
+  @override
+  String get scheduleLive => "/api/station/$_stationId/schedule/live";
+
+  @override
+  String get schedule => "/api/station/$_stationId/schedule";
+
+  // History endpoints
+  @override
+  String get historyLatest =>
+      "/api/station/$_stationId/streaming/history/latest-results";
+
+  // Media endpoints
+  @override
+  String get playlists => "/api/station/$_stationId/media/playlist";
+
+  @override
+  String get tags => "/api/station/$_stationId/media/tag";
+
+  /// Get headers for API requests
+  Map<String, String> getHeaders() {
+    return {
+      'x-api-key': _apiKey,
+      'Content-Type': 'application/json',
+    };
+  }
+}

--- a/lib/remote-data-source/radiocult/radiocult_remote_datasource.dart
+++ b/lib/remote-data-source/radiocult/radiocult_remote_datasource.dart
@@ -1,0 +1,201 @@
+import 'dart:async';
+
+import 'package:cuacfm/data/datasource/radiocult_remote_datasource.dart';
+import 'package:cuacfm/models/radiocult/radiocult.dart';
+import 'package:cuacfm/remote-data-source/network/radiocult_api.dart';
+import 'package:cuacfm/utils/simple_client.dart';
+import 'package:injector/injector.dart';
+
+/// Implementation of RadioCult remote data source
+class RadioCultRemoteDataSource implements RadioCultRemoteDataSourceContract {
+  final SimpleClient client;
+  final RadioCultAPIContract radioCultAPI;
+
+  RadioCultRemoteDataSource({
+    SimpleClient? client,
+    RadioCultAPIContract? api,
+  })  : client = client ?? Injector.appInstance.get<SimpleClient>(),
+        radioCultAPI = api ?? Injector.appInstance.get<RadioCultAPIContract>();
+
+  Map<String, String> get _headers => {
+        'x-api-key': radioCultAPI.apiKey,
+        'Content-Type': 'application/json',
+      };
+
+  Uri _buildUri(String path, [Map<String, String>? queryParams]) {
+    final uri = Uri.parse(radioCultAPI.baseUrl + path);
+    if (queryParams != null && queryParams.isNotEmpty) {
+      return uri.replace(queryParameters: queryParams);
+    }
+    return uri;
+  }
+
+  @override
+  Future<List<RadioCultArtist>> getArtists() async {
+    try {
+      final uri = _buildUri(radioCultAPI.artists);
+      final response = await client.get(uri, headers: _headers);
+
+      if (response is Map && response['success'] == true) {
+        final List<dynamic> data = response['data'] ?? [];
+        return data.map((json) => RadioCultArtist.fromJson(json)).toList();
+      }
+      return [];
+    } catch (e) {
+      print('Error fetching artists: $e');
+      return [];
+    }
+  }
+
+  @override
+  Future<RadioCultArtist?> getArtistById(String artistId) async {
+    try {
+      final uri = _buildUri(radioCultAPI.artistById(artistId));
+      final response = await client.get(uri, headers: _headers);
+
+      if (response is Map && response['success'] == true) {
+        return RadioCultArtist.fromJson(response['data']);
+      }
+      return null;
+    } catch (e) {
+      print('Error fetching artist by ID: $e');
+      return null;
+    }
+  }
+
+  @override
+  Future<RadioCultArtist?> getArtistBySlug(String slug) async {
+    try {
+      final uri = _buildUri(radioCultAPI.artistBySlug(slug));
+      final response = await client.get(uri, headers: _headers);
+
+      if (response is Map && response['success'] == true) {
+        return RadioCultArtist.fromJson(response['data']);
+      }
+      return null;
+    } catch (e) {
+      print('Error fetching artist by slug: $e');
+      return null;
+    }
+  }
+
+  @override
+  Future<List<RadioCultEvent>> getArtistSchedule(
+      String artistId, DateTime startDate, DateTime endDate) async {
+    try {
+      final uri = _buildUri(
+        radioCultAPI.artistSchedule(artistId),
+        {
+          'startDate': startDate.toUtc().toIso8601String(),
+          'endDate': endDate.toUtc().toIso8601String(),
+        },
+      );
+      final response = await client.get(uri, headers: _headers);
+
+      if (response is Map && response['success'] == true) {
+        final List<dynamic> data = response['data'] ?? [];
+        return data.map((json) => RadioCultEvent.fromJson(json)).toList();
+      }
+      return [];
+    } catch (e) {
+      print('Error fetching artist schedule: $e');
+      return [];
+    }
+  }
+
+  @override
+  Future<RadioCultLiveStatus?> getLiveStatus() async {
+    try {
+      final uri = _buildUri(radioCultAPI.scheduleLive);
+      final response = await client.get(uri, headers: _headers);
+
+      if (response is Map && response['success'] == true) {
+        return RadioCultLiveStatus.fromJson(response['data']);
+      }
+      return null;
+    } catch (e) {
+      print('Error fetching live status: $e');
+      return null;
+    }
+  }
+
+  @override
+  Future<List<RadioCultEvent>> getSchedule(DateTime startDate, DateTime endDate,
+      {bool expandArtist = false}) async {
+    try {
+      final queryParams = {
+        'startDate': startDate.toUtc().toIso8601String(),
+        'endDate': endDate.toUtc().toIso8601String(),
+      };
+      if (expandArtist) {
+        queryParams['expand'] = 'artist';
+      }
+
+      final uri = _buildUri(radioCultAPI.schedule, queryParams);
+      final response = await client.get(uri, headers: _headers);
+
+      if (response is Map && response['success'] == true) {
+        final List<dynamic> data = response['data'] ?? [];
+        return data.map((json) => RadioCultEvent.fromJson(json)).toList();
+      }
+      return [];
+    } catch (e) {
+      print('Error fetching schedule: $e');
+      return [];
+    }
+  }
+
+  @override
+  Future<List<RadioCultLastPlayed>> getHistory({int limit = 5}) async {
+    try {
+      final uri = _buildUri(
+        radioCultAPI.historyLatest,
+        {'limit': limit.clamp(1, 100).toString()},
+      );
+      final response = await client.get(uri, headers: _headers);
+
+      if (response is Map && response['success'] == true) {
+        final List<dynamic> data = response['data'] ?? [];
+        return data.map((json) => RadioCultLastPlayed.fromJson(json)).toList();
+      }
+      return [];
+    } catch (e) {
+      print('Error fetching history: $e');
+      return [];
+    }
+  }
+
+  @override
+  Future<List<RadioCultPlaylist>> getPlaylists() async {
+    try {
+      final uri = _buildUri(radioCultAPI.playlists);
+      final response = await client.get(uri, headers: _headers);
+
+      if (response is Map && response['success'] == true) {
+        final List<dynamic> data = response['data'] ?? [];
+        return data.map((json) => RadioCultPlaylist.fromJson(json)).toList();
+      }
+      return [];
+    } catch (e) {
+      print('Error fetching playlists: $e');
+      return [];
+    }
+  }
+
+  @override
+  Future<List<RadioCultTag>> getTags() async {
+    try {
+      final uri = _buildUri(radioCultAPI.tags);
+      final response = await client.get(uri, headers: _headers);
+
+      if (response is Map && response['success'] == true) {
+        final List<dynamic> data = response['data'] ?? [];
+        return data.map((json) => RadioCultTag.fromJson(json)).toList();
+      }
+      return [];
+    } catch (e) {
+      print('Error fetching tags: $e');
+      return [];
+    }
+  }
+}


### PR DESCRIPTION
This commit adds a complete integration layer for the RadioCult.fm API, enabling the app to leverage RadioCult for playlists and other services.

Changes include:
- RadioCult API configuration with authentication support (x-api-key header)
- Data models: Artist, Event, LiveStatus, Metadata, History, Playlist, Tag
- Remote data source with all RadioCult API endpoints
- Repository pattern implementation with proper error handling
- Use cases for all RadioCult features (artists, schedule, history, etc.)
- Dependency injection setup with configurable credentials

To use RadioCult, update lib/config/radiocult_config.dart with your station ID and API key from https://app.radiocult.fm/settings/cms/api