### PR TITLE
Fix/edge to edge UI polish

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -104,7 +104,8 @@
     "title" : "Error",
     "message" : "Whooops something failed :(",
     "internet_error" : "There is no internet connection",
-    "connection_error" : "We cannot contact our servers"
+    "connection_error" : "We cannot contact our servers",
+    "podcast_not_ready" : "Content is still loading, try again in a moment"
   },
   "actions" : {
     "close" : "Close",

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -104,7 +104,8 @@
     "title" : "Error",
     "message" : "Whooops hubo un problema no esperado :(",
     "internet_error" : "No dispones de conexión a internet",
-    "connection_error" : "No podemos conectar con el servidor en este momento"
+    "connection_error" : "No podemos conectar con el servidor en este momento",
+    "podcast_not_ready" : "El contenido aún está cargando, inténtalo en unos instantes"
   },
   "actions" : {
     "close" : "Cerrar",

--- a/assets/translations/gl.json
+++ b/assets/translations/gl.json
@@ -104,7 +104,8 @@
     "title" : "Erro",
     "message" : "Ups houbo un problema inesperado :(",
     "internet_error" : "Non dispós de conexión a internet",
-    "connection_error" : "Non podemos conectar co servidor neste momento"
+    "connection_error" : "Non podemos conectar co servidor neste momento",
+    "podcast_not_ready" : "O contido aínda está a cargar, inténtao nuns instantes"
   },
   "actions" : {
     "close" : "Fechar",

--- a/assets/translations/pt.json
+++ b/assets/translations/pt.json
@@ -104,7 +104,8 @@
     "title" : "Erro",
     "message" : "Ups, ocorreu um problema inesperado :(",
     "internet_error" : "Não tens ligação à internet",
-    "connection_error" : "Não conseguimos ligar ao servidor neste momento"
+    "connection_error" : "Não conseguimos ligar ao servidor neste momento",
+    "podcast_not_ready" : "O conteúdo ainda está a carregar, tente novamente em breve"
   },
   "actions" : {
     "close" : "Fechar",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,7 +13,6 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
-import 'package:package_info_plus/package_info_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart' as Foundation;
 import 'package:flutter/services.dart';
@@ -164,10 +163,8 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
     final prefs = await SharedPreferences.getInstance();
     final completed = prefs.getBool('onboarding_completed') ?? false;
     if (!completed) return;
-    final info = await PackageInfo.fromPlatform();
-    final currentBuild = int.tryParse(info.buildNumber) ?? 0;
-    final lastBuild = prefs.getInt('onboarding_version') ?? 0;
-    if (mounted && currentBuild <= lastBuild) setState(() => _showOnboarding = false);
+    final lastVersion = prefs.getInt('onboarding_version') ?? 0;
+    if (mounted && onboardingVersion <= lastVersion) setState(() => _showOnboarding = false);
   }
 
   Future<void> _loadLocale() async {

--- a/lib/models/new.dart
+++ b/lib/models/new.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:cuacfm/models/outstanding.dart';
 import 'package:cuacfm/translations/localizations.dart';
+import 'package:cuacfm/utils/html_entities.dart';
 import 'package:cuacfm/utils/safe_map.dart';
 import 'package:injector/injector.dart';
 import 'package:html/parser.dart' show parse;
@@ -19,7 +20,7 @@ class New {
   New(this.title, this.link, this.description, this.image, this.pubDate, {this.pubDateTime, this.category = ""});
 
   New.fromInstance(Map<String, dynamic> map)
-      : title = map["title"]?["\$t"] ?? map["title"] ?? "",
+      : title = HtmlEntities.decode(map["title"]?["\$t"] ?? map["title"] ?? ""),
         link = map["link"]?["\$t"] ?? map["link"] ?? "",
         pubDate = getDate(map["pubDate"]?["\$t"] ?? map["pubDate"] ?? ""),
         pubDateTime = parseDateTime(map["pubDate"]?["\$t"] ?? map["pubDate"] ?? ""),

--- a/lib/models/outstanding.dart
+++ b/lib/models/outstanding.dart
@@ -1,4 +1,5 @@
 import 'package:cuacfm/translations/localizations.dart';
+import 'package:cuacfm/utils/html_entities.dart';
 import 'package:cuacfm/utils/safe_map.dart';
 import 'package:injector/injector.dart';
 
@@ -10,7 +11,7 @@ class Outstanding {
    DateTime modified = DateTime(0);
 
   Outstanding.fromInstance(Map<String, dynamic> map)
-      : title = _cleanTitle((map["title"] as Map?)?["rendered"] ?? ""),
+      : title = _cleanTitle(HtmlEntities.decode((map["title"] as Map?)?["rendered"] ?? "")),
         description = (map["content"] as Map?)?["rendered"] ?? "",
         logoUrl = _extractLogoUrl(map),
         modified = DateTime.tryParse(map["modified"] ?? "") ?? DateTime(0);

--- a/lib/ui/alerts/alerts_view.dart
+++ b/lib/ui/alerts/alerts_view.dart
@@ -86,9 +86,11 @@ class _AlertsPageState extends State<AlertsPage>
     _isDark = _dark;
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle(
-        statusBarColor: _isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+        statusBarColor: Colors.transparent,
+        systemStatusBarContrastEnforced: false,
         statusBarIconBrightness: _isDark ? Brightness.light : Brightness.dark,
-        systemNavigationBarColor: _isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+        systemNavigationBarColor: Colors.transparent,
+        systemNavigationBarContrastEnforced: false,
         systemNavigationBarIconBrightness: _isDark ? Brightness.light : Brightness.dark,
       ),
       child: Scaffold(

--- a/lib/ui/episode-detail/episode_detail_view.dart
+++ b/lib/ui/episode-detail/episode_detail_view.dart
@@ -135,12 +135,14 @@ class _EpisodeDetailState extends State<EpisodeDetail>
 
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle(
-        statusBarColor: Colors.transparent,
-        systemStatusBarContrastEnforced: false,
+        statusBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
         statusBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
-        systemNavigationBarColor: Colors.transparent,
-        systemNavigationBarContrastEnforced: false,
-        systemNavigationBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
+        systemNavigationBarColor: showPlayer
+            ? Colors.black
+            : (isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6)),
+        systemNavigationBarIconBrightness: showPlayer
+            ? Brightness.light
+            : (isDark ? Brightness.light : Brightness.dark),
       ),
       child: Scaffold(
         backgroundColor: _colors.palidwhite,

--- a/lib/ui/episode-detail/episode_detail_view.dart
+++ b/lib/ui/episode-detail/episode_detail_view.dart
@@ -133,54 +133,63 @@ class _EpisodeDetailState extends State<EpisodeDetail>
     final isDark = themeMode == ThemeMode.dark || (themeMode == ThemeMode.system && _queryData.platformBrightness == Brightness.dark);
     final showPlayer = _currentPlayer.isPlaying() || _currentPlayer.isPaused();
 
-    return AnnotatedRegion<SystemUiOverlayStyle>(
-      value: SystemUiOverlayStyle(
-        statusBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
-        statusBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
-        systemNavigationBarColor: showPlayer
-            ? Colors.black
-            : (isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6)),
-        systemNavigationBarIconBrightness: showPlayer
-            ? Brightness.light
-            : (isDark ? Brightness.light : Brightness.dark),
-      ),
-      child: Scaffold(
-        backgroundColor: _colors.palidwhite,
-        body: _getBodyLayout(),
-        bottomNavigationBar: showPlayer
-            ? Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  PlayerView(
-                    shouldShow: true,
-                    isPlayingAudio: _currentPlayer.isPlaying(),
-                    onDetailClicked: () {
-                      Navigator.of(context).push(MaterialPageRoute(
-                        builder: (_) => PodcastControls(
-                          episode: _currentPlayer.episode,
-                        ),
-                      ));
-                    },
-                    onCloseClicked: () {
-                      _currentPlayer.stop();
-                      if (mounted) setState(() {});
-                    },
-                    onMultimediaClicked: (isPlaying) {
-                      if (!mounted) return;
-                      if (isPlaying) {
-                        _currentPlayer.pause();
-                      } else {
-                        _currentPlayer.resume();
-                      }
-                      setState(() {});
-                    },
-                  ),
-                  if (_queryData.padding.bottom > 0)
-                    Container(height: _queryData.padding.bottom, color: Colors.black),
-                ],
-              )
-            : SizedBox.shrink(),
-      ),
+    return Stack(
+      children: [
+        AnnotatedRegion<SystemUiOverlayStyle>(
+          value: SystemUiOverlayStyle(
+            statusBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+            statusBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
+            systemNavigationBarColor: showPlayer
+                ? Colors.black
+                : (isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6)),
+            systemNavigationBarIconBrightness: showPlayer
+                ? Brightness.light
+                : (isDark ? Brightness.light : Brightness.dark),
+          ),
+          child: Scaffold(
+            backgroundColor: _colors.palidwhite,
+            body: _getBodyLayout(),
+            bottomNavigationBar: showPlayer
+                ? Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      PlayerView(
+                        shouldShow: true,
+                        isPlayingAudio: _currentPlayer.isPlaying(),
+                        onDetailClicked: () {
+                          Navigator.of(context).push(MaterialPageRoute(
+                            builder: (_) => PodcastControls(
+                              episode: _currentPlayer.episode,
+                            ),
+                          ));
+                        },
+                        onCloseClicked: () {
+                          _currentPlayer.stop();
+                          if (mounted) setState(() {});
+                        },
+                        onMultimediaClicked: (isPlaying) {
+                          if (!mounted) return;
+                          if (isPlaying) {
+                            _currentPlayer.pause();
+                          } else {
+                            _currentPlayer.resume();
+                          }
+                          setState(() {});
+                        },
+                      ),
+                      if (_queryData.padding.bottom > 0)
+                        Container(height: _queryData.padding.bottom, color: Colors.black),
+                    ],
+                  )
+                : SizedBox.shrink(),
+          ),
+        ),
+        Positioned(
+          top: 0, left: 0, right: 0,
+          height: _queryData.padding.top,
+          child: ColoredBox(color: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6)),
+        ),
+      ],
     );
   }
 

--- a/lib/ui/episode-detail/episode_detail_view.dart
+++ b/lib/ui/episode-detail/episode_detail_view.dart
@@ -187,7 +187,7 @@ class _EpisodeDetailState extends State<EpisodeDetail>
         Positioned(
           top: 0, left: 0, right: 0,
           height: _queryData.padding.top,
-          child: ColoredBox(color: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6)),
+          child: ColoredBox(color: _colors.palidwhite),
         ),
       ],
     );

--- a/lib/ui/episode-detail/episode_detail_view.dart
+++ b/lib/ui/episode-detail/episode_detail_view.dart
@@ -135,42 +135,47 @@ class _EpisodeDetailState extends State<EpisodeDetail>
 
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle(
-        statusBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+        statusBarColor: Colors.transparent,
+        systemStatusBarContrastEnforced: false,
         statusBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
-        systemNavigationBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+        systemNavigationBarColor: Colors.transparent,
+        systemNavigationBarContrastEnforced: false,
         systemNavigationBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
       ),
       child: Scaffold(
         backgroundColor: _colors.palidwhite,
         body: _getBodyLayout(),
         bottomNavigationBar: showPlayer
-            ? MediaQuery.removePadding(
-                context: context,
-                removeBottom: true,
-                child: PlayerView(
-                  shouldShow: true,
-                  isPlayingAudio: _currentPlayer.isPlaying(),
-                  onDetailClicked: () {
-                    Navigator.of(context).push(MaterialPageRoute(
-                      builder: (_) => PodcastControls(
-                        episode: _currentPlayer.episode,
-                      ),
-                    ));
-                  },
-                  onCloseClicked: () {
-                    _currentPlayer.stop();
-                    if (mounted) setState(() {});
-                  },
-                  onMultimediaClicked: (isPlaying) {
-                    if (!mounted) return;
-                    if (isPlaying) {
-                      _currentPlayer.pause();
-                    } else {
-                      _currentPlayer.resume();
-                    }
-                    setState(() {});
-                  },
-                ),
+            ? Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  PlayerView(
+                    shouldShow: true,
+                    isPlayingAudio: _currentPlayer.isPlaying(),
+                    onDetailClicked: () {
+                      Navigator.of(context).push(MaterialPageRoute(
+                        builder: (_) => PodcastControls(
+                          episode: _currentPlayer.episode,
+                        ),
+                      ));
+                    },
+                    onCloseClicked: () {
+                      _currentPlayer.stop();
+                      if (mounted) setState(() {});
+                    },
+                    onMultimediaClicked: (isPlaying) {
+                      if (!mounted) return;
+                      if (isPlaying) {
+                        _currentPlayer.pause();
+                      } else {
+                        _currentPlayer.resume();
+                      }
+                      setState(() {});
+                    },
+                  ),
+                  if (_queryData.padding.bottom > 0)
+                    Container(height: _queryData.padding.bottom, color: Colors.black),
+                ],
               )
             : SizedBox.shrink(),
       ),

--- a/lib/ui/home/home_view.dart
+++ b/lib/ui/home/home_view.dart
@@ -109,10 +109,12 @@ class MyHomePageState extends State<MyHomePage>
         (themeMode == ThemeMode.system && queryData.platformBrightness == Brightness.dark);
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle(
-        statusBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+        statusBarColor: Colors.transparent,
+        systemStatusBarContrastEnforced: false,
         statusBarBrightness: isDark ? Brightness.dark : Brightness.light,
         statusBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
-        systemNavigationBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+        systemNavigationBarColor: Colors.transparent,
+        systemNavigationBarContrastEnforced: false,
         systemNavigationBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
       ),
       child: Stack(
@@ -319,11 +321,12 @@ class MyHomePageState extends State<MyHomePage>
     final brightness = WidgetsBinding.instance.platformDispatcher.platformBrightness;
     final isDark = brightness == Brightness.dark;
     SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
-      systemStatusBarContrastEnforced: true,
-      statusBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+      systemStatusBarContrastEnforced: false,
+      statusBarColor: Colors.transparent,
       statusBarBrightness: isDark ? Brightness.dark : Brightness.light,
       statusBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
-      systemNavigationBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+      systemNavigationBarColor: Colors.transparent,
+      systemNavigationBarContrastEnforced: false,
       systemNavigationBarDividerColor: Colors.transparent,
       systemNavigationBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
     ));
@@ -781,30 +784,28 @@ class MyHomePageState extends State<MyHomePage>
         override: true,
       );
       SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
-          systemStatusBarContrastEnforced: true,
-          statusBarColor: Color(0xFFFAF9F6),
+          systemStatusBarContrastEnforced: false,
+          statusBarColor: Colors.transparent,
           statusBarBrightness: Brightness.light,
           statusBarIconBrightness: Brightness.dark,
-          systemNavigationBarColor: Color(0xFFFAF9F6),
+          systemNavigationBarColor: Colors.transparent,
+          systemNavigationBarContrastEnforced: false,
           systemNavigationBarDividerColor: Colors.transparent,
           systemNavigationBarIconBrightness: Brightness.dark));
-      SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
-          overlays: [SystemUiOverlay.top, SystemUiOverlay.bottom]);
     } else {
       Injector.appInstance.registerSingleton<RadiocomColorsConract>(
         () => RadiocomColorsDark(),
         override: true,
       );
       SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
-          systemStatusBarContrastEnforced: true,
-          statusBarColor: Color(0xFF1A1A1A),
+          systemStatusBarContrastEnforced: false,
+          statusBarColor: Colors.transparent,
           statusBarBrightness: Brightness.dark,
           statusBarIconBrightness: Brightness.light,
-          systemNavigationBarColor: Color(0xFF1A1A1A),
+          systemNavigationBarColor: Colors.transparent,
+          systemNavigationBarContrastEnforced: false,
           systemNavigationBarDividerColor: Colors.transparent,
           systemNavigationBarIconBrightness: Brightness.light));
-      SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
-          overlays: [SystemUiOverlay.top, SystemUiOverlay.bottom]);
     }
   }
 

--- a/lib/ui/home/home_view.dart
+++ b/lib/ui/home/home_view.dart
@@ -277,8 +277,9 @@ class MyHomePageState extends State<MyHomePage>
     return doc.body?.text.trim() ?? '';
   }
 
-  Program findPodcastByName(String url) {
-    return _podcast.where((element) => url == element.rssUrl).first;
+  Program? findPodcastByName(String url) {
+    final matches = _podcast.where((element) => url == element.rssUrl);
+    return matches.isEmpty ? null : matches.first;
   }
 
   generatePodcast() {
@@ -1226,7 +1227,7 @@ Builder(builder: (context) {
                       orElse: () => _timeTable.last,
                     );
                   Program? nextProgram;
-                  try { nextProgram = findPodcastByName(next.rssUrl); } catch (_) {}
+                  nextProgram = findPodcastByName(next.rssUrl);
                   final nextLabel = SafeMap.safe(_localization.translateMap("home"), ["schedule_next"]).isNotEmpty
                       ? SafeMap.safe(_localization.translateMap("home"), ["schedule_next"])
                       : "Next";
@@ -1868,7 +1869,14 @@ Builder(builder: (context) {
         onTap: () async {
           if (_loadingRssUrl != null) return;
           if (item.rssUrl.isEmpty) {
-            _presenter.onPodcastClicked(findPodcastByName(item.rssUrl));
+            final podcast = findPodcastByName(item.rssUrl);
+            if (podcast != null) {
+              _presenter.onPodcastClicked(podcast);
+            } else {
+              ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                content: Text(SafeMap.safe(_localization.translateMap("error"), ["podcast_not_ready"])),
+              ));
+            }
             return;
           }
           if (mounted) setState(() => _loadingRssUrl = item.rssUrl);
@@ -1878,7 +1886,14 @@ Builder(builder: (context) {
           if (mounted) setState(() => _loadingRssUrl = null);
           final episodes = result.data ?? [];
           if (episodes.isEmpty) {
-            _presenter.onPodcastClicked(findPodcastByName(item.rssUrl));
+            final podcast = findPodcastByName(item.rssUrl);
+            if (podcast != null) {
+              _presenter.onPodcastClicked(podcast);
+            } else {
+              ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                content: Text(SafeMap.safe(_localization.translateMap("error"), ["podcast_not_ready"])),
+              ));
+            }
             return;
           }
           episodes.sort((a, b) =>

--- a/lib/ui/new-detail/new_detail.dart
+++ b/lib/ui/new-detail/new_detail.dart
@@ -52,9 +52,11 @@ class NewDetailState extends State<NewDetail>
     final isDark = themeMode == ThemeMode.dark || (themeMode == ThemeMode.system && _queryData.platformBrightness == Brightness.dark);
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle(
-        statusBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+        statusBarColor: Colors.transparent,
+        systemStatusBarContrastEnforced: false,
         statusBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
-        systemNavigationBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+        systemNavigationBarColor: Colors.transparent,
+        systemNavigationBarContrastEnforced: false,
         systemNavigationBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
       ),
       child: Stack(
@@ -66,32 +68,35 @@ class NewDetailState extends State<NewDetail>
         bottomNavigationBar: Container(
           color: _colors.palidwhite,
           child: shouldShowPlayer
-              ? MediaQuery.removePadding(
-                  context: context,
-                  removeBottom: true,
-                  child: PlayerView(
-                      shouldShow: shouldShowPlayer,
-                      isPlayingAudio: _presenter.currentPlayer.isPlaying(),
-                      onDetailClicked: () {
-                        _presenter.onPodcastControlsClicked(
-                            _presenter.currentPlayer.episode);
-                      },
-                      onCloseClicked: () {
-                        _presenter.currentPlayer.stop();
-                        if (mounted) setState(() { shouldShowPlayer = false; });
-                      },
-                      onMultimediaClicked: (isPlaying) {
-                        if (!mounted) return;
-                        setState(() {
-                          if (isPlaying) {
-                            _presenter.onPause();
-                          } else {
-                            _presenter.onResume();
-                          }
-                        });
-                      }),
+              ? Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    PlayerView(
+                        shouldShow: shouldShowPlayer,
+                        isPlayingAudio: _presenter.currentPlayer.isPlaying(),
+                        onDetailClicked: () {
+                          _presenter.onPodcastControlsClicked(
+                              _presenter.currentPlayer.episode);
+                        },
+                        onCloseClicked: () {
+                          _presenter.currentPlayer.stop();
+                          if (mounted) setState(() { shouldShowPlayer = false; });
+                        },
+                        onMultimediaClicked: (isPlaying) {
+                          if (!mounted) return;
+                          setState(() {
+                            if (isPlaying) {
+                              _presenter.onPause();
+                            } else {
+                              _presenter.onResume();
+                            }
+                          });
+                        }),
+                    if (_queryData.padding.bottom > 0)
+                      Container(height: _queryData.padding.bottom, color: Colors.black),
+                  ],
                 )
-              : SizedBox(height: MediaQuery.of(context).padding.bottom),
+              : SizedBox(height: _queryData.padding.bottom),
         ),
           ),
           if (_isLoadingEpisode)

--- a/lib/ui/new-detail/new_detail.dart
+++ b/lib/ui/new-detail/new_detail.dart
@@ -101,6 +101,11 @@ class NewDetailState extends State<NewDetail>
               : SizedBox(height: _queryData.padding.bottom),
         ),
           ),
+          Positioned(
+            top: 0, left: 0, right: 0,
+            height: _queryData.padding.top,
+            child: ColoredBox(color: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6)),
+          ),
           if (_isLoadingEpisode)
             Container(
               color: Colors.black.withValues(alpha: 0.4),

--- a/lib/ui/new-detail/new_detail.dart
+++ b/lib/ui/new-detail/new_detail.dart
@@ -104,7 +104,7 @@ class NewDetailState extends State<NewDetail>
           Positioned(
             top: 0, left: 0, right: 0,
             height: _queryData.padding.top,
-            child: ColoredBox(color: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6)),
+            child: ColoredBox(color: _colors.palidwhite),
           ),
           if (_isLoadingEpisode)
             Container(

--- a/lib/ui/new-detail/new_detail.dart
+++ b/lib/ui/new-detail/new_detail.dart
@@ -52,12 +52,14 @@ class NewDetailState extends State<NewDetail>
     final isDark = themeMode == ThemeMode.dark || (themeMode == ThemeMode.system && _queryData.platformBrightness == Brightness.dark);
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle(
-        statusBarColor: Colors.transparent,
-        systemStatusBarContrastEnforced: false,
+        statusBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
         statusBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
-        systemNavigationBarColor: Colors.transparent,
-        systemNavigationBarContrastEnforced: false,
-        systemNavigationBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
+        systemNavigationBarColor: shouldShowPlayer
+            ? Colors.black
+            : (isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6)),
+        systemNavigationBarIconBrightness: shouldShowPlayer
+            ? Brightness.light
+            : (isDark ? Brightness.light : Brightness.dark),
       ),
       child: Stack(
         children: [

--- a/lib/ui/onboarding/onboarding_view.dart
+++ b/lib/ui/onboarding/onboarding_view.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'package:cuacfm/domain/repository/radiocom_repository_contract.dart';
-import 'package:package_info_plus/package_info_plus.dart';
 import 'package:cuacfm/main.dart';
 import 'package:cuacfm/models/episode.dart';
 import 'package:cuacfm/models/program.dart';
@@ -13,6 +12,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 const _yellow = Color(0xFFFCD444);
 const _dark = Color(0xFF1A1A1A);
+const onboardingVersion = 1;
 
 class OnboardingView extends StatefulWidget {
   final VoidCallback onFinished;
@@ -226,10 +226,7 @@ void _toggleFavorite(Program program) {
       MyApp.setLocale(MyApp.parseLocale(_selectedLocale));
     }
     await prefs.setBool('onboarding_completed', true);
-    try {
-      final info = await PackageInfo.fromPlatform();
-      await prefs.setInt('onboarding_version', int.tryParse(info.buildNumber) ?? 0);
-    } catch (_) {}
+    await prefs.setInt('onboarding_version', onboardingVersion);
     widget.onFinished();
   }
 

--- a/lib/ui/podcast/all_podcast/all_podcast_view.dart
+++ b/lib/ui/podcast/all_podcast/all_podcast_view.dart
@@ -56,9 +56,11 @@ class AllPodcastState extends State<AllPodcast>
     final isDark = themeMode == ThemeMode.dark || (themeMode == ThemeMode.system && MediaQuery.of(context).platformBrightness == Brightness.dark);
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle(
-        statusBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+        statusBarColor: Colors.transparent,
+        systemStatusBarContrastEnforced: false,
         statusBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
-        systemNavigationBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+        systemNavigationBarColor: Colors.transparent,
+        systemNavigationBarContrastEnforced: false,
         systemNavigationBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
       ),
       child: Scaffold(

--- a/lib/ui/podcast/all_podcast/all_podcast_view.dart
+++ b/lib/ui/podcast/all_podcast/all_podcast_view.dart
@@ -235,7 +235,8 @@ class AllPodcastState extends State<AllPodcast>
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Expanded(
+                    AspectRatio(
+                      aspectRatio: 1.0,
                       child: ClipRRect(
                         borderRadius: BorderRadius.circular(12),
                         child: CustomImage(

--- a/lib/ui/podcast/detail_podcast_view.dart
+++ b/lib/ui/podcast/detail_podcast_view.dart
@@ -140,14 +140,13 @@ class DetailPodcastState extends State<DetailPodcastPage>
     final statusBarNeedsDarkIcons = _paletteColor.computeLuminance() > 0.179;
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle(
-        statusBarColor: _isScrolled
-            ? (isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6))
-            : Colors.transparent,
+        statusBarColor: Colors.transparent,
         systemStatusBarContrastEnforced: false,
         statusBarIconBrightness: _isScrolled
             ? (isDark ? Brightness.light : Brightness.dark)
             : (statusBarNeedsDarkIcons ? Brightness.dark : Brightness.light),
-        systemNavigationBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+        systemNavigationBarColor: Colors.transparent,
+        systemNavigationBarContrastEnforced: false,
         systemNavigationBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
       ),
       child: _scaffold,

--- a/lib/ui/settings/settings-detail/settings_detail.dart
+++ b/lib/ui/settings/settings-detail/settings_detail.dart
@@ -52,9 +52,11 @@ class SettingsDetailState extends State<SettingsDetail>
     final isDark = MediaQuery.of(context).platformBrightness == Brightness.dark;
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle(
-        statusBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+        statusBarColor: Colors.transparent,
+        systemStatusBarContrastEnforced: false,
         statusBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
-        systemNavigationBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+        systemNavigationBarColor: Colors.transparent,
+        systemNavigationBarContrastEnforced: false,
         systemNavigationBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
       ),
       child: Scaffold(

--- a/lib/ui/settings/settings.dart
+++ b/lib/ui/settings/settings.dart
@@ -68,9 +68,11 @@ class SettingsState extends State<Settings>
     _localization = Injector.appInstance.get<CuacLocalization>();
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle(
-        statusBarColor: _isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+        statusBarColor: Colors.transparent,
+        systemStatusBarContrastEnforced: false,
         statusBarIconBrightness: _isDark ? Brightness.light : Brightness.dark,
-        systemNavigationBarColor: _isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+        systemNavigationBarColor: Colors.transparent,
+        systemNavigationBarContrastEnforced: false,
         systemNavigationBarIconBrightness: _isDark ? Brightness.light : Brightness.dark,
       ),
       child: Scaffold(

--- a/lib/ui/timetable/time_table_view.dart
+++ b/lib/ui/timetable/time_table_view.dart
@@ -54,9 +54,11 @@ class TimetableState extends State<Timetable>
     final isDark = themeMode == ThemeMode.dark || (themeMode == ThemeMode.system && queryData.platformBrightness == Brightness.dark);
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle(
-        statusBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+        statusBarColor: Colors.transparent,
+        systemStatusBarContrastEnforced: false,
         statusBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
-        systemNavigationBarColor: isDark ? const Color(0xFF1A1A1A) : const Color(0xFFFAF9F6),
+        systemNavigationBarColor: Colors.transparent,
+        systemNavigationBarContrastEnforced: false,
         systemNavigationBarIconBrightness: isDark ? Brightness.light : Brightness.dark,
       ),
       child: Scaffold(

--- a/lib/utils/bottom_bar.dart
+++ b/lib/utils/bottom_bar.dart
@@ -60,6 +60,7 @@ class BottomBar extends StatelessWidget {
     final tabNews = SafeMap.safe(_localization.translateMap("home"), ["tab_news"]).isNotEmpty ? SafeMap.safe(_localization.translateMap("home"), ["tab_news"]) : "Novas";
     final tabFavourites = SafeMap.safe(_localization.translateMap("home"), ["tab_favourites"]).isNotEmpty ? SafeMap.safe(_localization.translateMap("home"), ["tab_favourites"]) : "Favoritos";
     final tabMenu = SafeMap.safe(_localization.translateMap("home"), ["tab_menu"]).isNotEmpty ? SafeMap.safe(_localization.translateMap("home"), ["tab_menu"]) : "Menú";
+    final bottomInset = queryData.padding.bottom;
 
     return Container(
         key: Key("bottom_bar"),
@@ -68,7 +69,7 @@ class BottomBar extends StatelessWidget {
           color: _colors.palidwhite,
         ),
         width: queryData.size.width,
-        height: (!Foundation.kIsWeb && Platform.isAndroid) ? 85 : 100,
+        height: ((!Foundation.kIsWeb && Platform.isAndroid) ? 85 : 100) + bottomInset,
         child: Column(children: [
           SizedBox(height: 10.0),
           Container(
@@ -125,7 +126,8 @@ class BottomBar extends StatelessWidget {
                         iconSize: 25,
                       )),
                 ],
-              ))
+              )),
+          if (bottomInset > 0) SizedBox(height: bottomInset),
         ]));
   }
 }

--- a/lib/utils/html_entities.dart
+++ b/lib/utils/html_entities.dart
@@ -1,0 +1,8 @@
+import 'package:html/parser.dart' show parse;
+
+class HtmlEntities {
+  static String decode(String text) {
+    if (!text.contains('&')) return text;
+    return parse(text).body?.text ?? text;
+  }
+}


### PR DESCRIPTION
- Corrixe a cor das barras de sistema (status bar / navigation bar) en modo edge-to-edge para que coincidan co tema (claro/escuro) en todas as pantallas.
- Nas pantallas de detalle de nova e de episodio (imaxe de cabeceira a pantalla completa), restaura unha status bar opaca coa cor do tema (en vez de transparente) para que a imaxe non se vexa a través dela; a barra de navegación inferior segue a cor do tema, ou negra cando o reprodutor está visible para combinar co fondo do PlayerView.
- Decodifica entidades HTML (`&#8220;`, `&quot;`, etc.) nos títulos de noticias e destacados mediante un novo helper `HtmlEntities`.
- Reserva espazo para a barra de xestos/navegación de Android baixo o `BottomBar` e o `PlayerView` para que non queden tapados.

## Test plan

- [x] `flutter analyze lib test` sen incidencias
- [x] `flutter test` 402/402 tests pasando
- [ ] Probar en dispositivo Android con xestos en modo claro e escuro
""",
